### PR TITLE
Fix error handling for getcwd

### DIFF
--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -803,12 +803,14 @@ int NinjaMain::ToolCompilationDatabase(const Options* options, int argc,
 
   bool first = true;
   vector<char> cwd;
+  char* success = NULL;
 
   do {
     cwd.resize(cwd.size() + 1024);
     errno = 0;
-  } while (!getcwd(&cwd[0], cwd.size()) && errno == ERANGE);
-  if (errno != 0 && errno != ERANGE) {
+    success = getcwd(&cwd[0], cwd.size());
+  } while (!success && errno == ERANGE);
+  if (!success) {
     Error("cannot determine working directory: %s", strerror(errno));
     return 1;
   }


### PR DESCRIPTION
Quoting from the Linux man page for errno,

"The value in errno is significant only when the return value of the call
indicated an error (i.e., -1 from most system calls; -1 or NULL from most
library functions); a function that succeeds is allowed to change errno. The
value of errno is never set to zero by any system call or library function."

Successful calls to getcwd are allowed to set errno causing the compilation
database not to be written. Spurious failures of this nature were observed on
AIX.

Adjust the error handling for getcwd so that errno is only checked if the call
returned NULL.