### PR TITLE
Fix logic-error in IsPathDead, see #1432

### DIFF
--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -154,7 +154,7 @@ struct NinjaMain : public BuildLogUser {
 
   virtual bool IsPathDead(StringPiece s) const {
     Node* n = state_.LookupNode(s);
-    if (!n || !n->in_edge())
+    if (n && n->in_edge())
       return false;
     // Just checking n isn't enough: If an old output is both in the build log
     // and in the deps log, it will have a Node object in state_.  (It will also


### PR DESCRIPTION
The conditional `(!n || !n->in_edge()) && ` was moved up. It now needs
to be inversed because there's a `return false;`. See
https://github.com/ninja-build/ninja/commit/3beebde51a2089ecb01820f1428efe0263deaeea#diff-78294872cbf9d32f4f972288561fa718R146
and
https://github.com/ninja-build/ninja/pull/1432#discussion_r321827528